### PR TITLE
Display a part of the index.html template as landing page

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -116,6 +116,7 @@
                   </ul>
                 </div>
               </section>
+              {% if render_complete_home %}
               <section class="more">
                 <div class="how-it-works max-size-1000">
                   <h2 class="big">Comment ça marche ?</h2>
@@ -213,6 +214,7 @@
                   </div>
                 </footer>
               </section>
+              {% endif %}
             </main>
           </div>
         </div>

--- a/labonnealternance/react_proxy/views.py
+++ b/labonnealternance/react_proxy/views.py
@@ -40,6 +40,10 @@ class ReactProxyAppView(View):
         if not path.endswith('.css') and not path.endswith('.js') and not path.endswith('.ico'):
             params = { 'title': self.compute_page_title(path) }
 
+            # Render all index.html only in home page
+            if path == '/':
+                params.update({ 'render_complete_home': True })
+
             # Company details
             if path.startswith("/details-entreprises/"):
                 params = self.get_company_details_as_param(path, params)


### PR DESCRIPTION
Currently, we create a index.html which prerender all the home page; but its slows down the display of the final page with extra download and parsing.
To avoid that, we only display the top part of the home page in other page than the home page.