### PR TITLE
Create an accessible modal component

### DIFF
--- a/frontend/src/components/companies/blocks/company_modal.js
+++ b/frontend/src/components/companies/blocks/company_modal.js
@@ -9,6 +9,7 @@ import { SoftSkillsService } from '../../../services/soft_skills/soft_skills.ser
 import { CompanyDetailsCommon, CompanyCoordinates, CompanyIntroduction, PrepareApplication } from '../../shared/company_details_commun/company_details_commun';
 import { GoogleAdwordsService } from '../../../services/google_adword.service';
 import throttle from 'lodash/throttle';
+import Modal from '../../shared/modal';
 
 
 const FOOTER_HEIGHT_DELTA = 50;
@@ -68,7 +69,7 @@ export class CompanyModal extends Component {
     }
 
     componentDidUpdate() {
-        if(!this.hasScrollEventListener) this.initModalEventListener();
+        if (!this.hasScrollEventListener) this.initModalEventListener();
     }
 
     componentWillUnmount() {
@@ -78,7 +79,7 @@ export class CompanyModal extends Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-        let fields= ['searchTerm', 'company', 'showCoordinates'];
+        let fields = ['searchTerm', 'company', 'showCoordinates'];
         return fields.some(field => this.state[field] !== nextState[field]);
     }
 
@@ -99,7 +100,7 @@ export class CompanyModal extends Component {
 
     initModalEventListener = () => {
         let modal = document.querySelectorAll('.modal-content')[0];
-        if(!modal) return null;
+        if (!modal) return null;
 
         modal.addEventListener("scroll", this.updateCoordinatesFn);
         this.hasScrollEventListener = true;
@@ -108,7 +109,7 @@ export class CompanyModal extends Component {
 
     computeCoordinatesTopValue = () => {
         let modal = document.querySelectorAll('.modal-content')[0];
-        if(!modal) return null;
+        if (!modal) return null;
 
         let modalHeight = modal.offsetHeight; // Height on screen
         let modalScrollHeight = modal.scrollHeight; // Height needed for no scrolling
@@ -116,16 +117,16 @@ export class CompanyModal extends Component {
         let coordinatesHeight = document.querySelectorAll('.how-to-apply')[0].offsetHeight;
 
         // We got a scroll => Coordinates at bottom
-        if(modalHeight < modalScrollHeight + coordinatesHeight) {
+        if (modalHeight < modalScrollHeight + coordinatesHeight) {
             let newTopValue = modalHeight + scrollTop - coordinatesHeight;
             // If scrollbar is near to the bottom, we decrease the top value in order to see the company footer
-            if(modalHeight + scrollTop + FOOTER_HEIGHT_DELTA/2 >= modalScrollHeight) newTopValue -= FOOTER_HEIGHT_DELTA;
+            if (modalHeight + scrollTop + FOOTER_HEIGHT_DELTA / 2 >= modalScrollHeight) newTopValue -= FOOTER_HEIGHT_DELTA;
 
             this.setState({ coordinateTop: { 'position': 'absolute', 'left': 0, 'top': newTopValue } });
             this.forceUpdate();
         } else {
             // All the modal is visible ? We disabled sticky bottom
-            if(this.state.coordinateTop !== undefined) {
+            if (this.state.coordinateTop !== undefined) {
                 this.setState({ coordinateTop: undefined });
                 this.forceUpdate();
             }
@@ -150,33 +151,26 @@ export class CompanyModal extends Component {
         const company = this.state.company;
 
         return (
-            <div className="modal">
-                <div className="modal-bg" onClick={this.closeModal}>&nbsp;</div>
-                <div className="modal-content">
-                    <div className="actions-zone">
-                        <button onClick={this.closeModal}><span className="icon close-icon">&nbsp;</span></button>
-                    </div>
-                    {CompanyDetailsCommon.renderTitle(company)}
+            <Modal title={"Détails de l'entreprise : " + company.name } onClose={this.closeModal}>
+                {CompanyDetailsCommon.renderTitle(company)}
 
-                    <small className="siret">SIRET: {company.siret}</small>
+                <small className="siret">SIRET: {company.siret}</small>
 
-                    <div className="modal-body">
-                        <h2><span className="badge">1</span>Informez-vous sur l'entreprise</h2>
-                        <CompanyIntroduction company={company} />
-                        <hr />
+                <div className="modal-body">
+                    <h2><span className="badge">1</span>Informez-vous sur l'entreprise</h2>
+                    <CompanyIntroduction company={company} />
+                    <hr />
 
-                        <h2><span className="badge">2</span>Préparez votre candidature spontanée</h2>
-                        <PrepareApplication company={company} rome={company.job.rome} />
+                    <h2><span className="badge">2</span>Préparez votre candidature spontanée</h2>
+                    <PrepareApplication company={company} rome={company.job.rome} />
 
-                        {this.renderHowToApply(company)}
-                    </div>
-
-                    <div className="company-footer">
-                        <a href={this.state.recruiterAccessUrl} target="blank" title="Ouverture dans une nouvelle fenêtre">C'est mon entreprise et je souhaite en modifier les informations</a>
-                    </div>
+                    {this.renderHowToApply(company)}
                 </div>
 
-            </div>
+                <div className="company-footer">
+                    <a href={this.state.recruiterAccessUrl} target="blank" title="Ouverture dans une nouvelle fenêtre">C'est mon entreprise et je souhaite en modifier les informations</a>
+                </div>
+            </Modal>
         );
     }
 }

--- a/frontend/src/components/companies/companies.js
+++ b/frontend/src/components/companies/companies.js
@@ -114,7 +114,7 @@ class Companies extends Component {
             SEOService.displayNoFollow(true);
         } else {
             // On mobile, on first result page ever : display the number of results
-            let showMobileResultPopup = localStorage.getItem(SHOW_RESULT_POPUP_KEY) === null;
+            let showMobileResultPopup = localStorage.getItem(SHOW_RESULT_POPUP_KEY) === null && this.state.mobileVersion;
             if (showMobileResultPopup) {
                 let message = CompaniesService.computeResultTitle(companyCount, this.state.searchTerm, this.state.cityName);
                 NotificationService.createInfo(message, SHOW_RESULT_POPUP_KEY);

--- a/frontend/src/components/shared/modal.js
+++ b/frontend/src/components/shared/modal.js
@@ -1,0 +1,131 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+
+/**
+ *
+ * Accessibility rules for modal :
+ * - When the Modal is not open, it is not rendered into the DOM ==> need to be handle in parent component
+ * - ✅ When rendered, the Modal is appended to the end of document.body. ==> Done with preact-portal
+ * - ✅ The Modal has relevant WAI-ARIA attributes in accordance with accessibility guidelines
+ *    => aria-modal="true"
+ *    => role="dialog" ou "alertdialog" (last one if immediate attention is required)
+ *    => aria-label
+ * - ✅ Pressing the escape key will close the Modal.
+ * - ✅ Clicking outside the Modal will close it.
+ * - ✅ When open, scrolling is frozen on the main document beneath the Modal.
+ * - ✅ When open, focus is drawn immediately to the Modal's close button.
+ * - ✅ When the Modal closes, focus returns to the Modal's trigger button.
+ * - ✅ Focus is trapped within the Modal when open => ensure by tabindex="-1"
+ *
+ * Sources :
+ *  - https://assortment.io/posts/accessible-modal-component-react-portals-part-1
+ *  - https://assortment.io/posts/accessible-modal-component-react-portals-part-2
+ */
+
+// Focus handling inspired by https://github.com/ghosh/micromodal
+const FOCUSABLE_ELEMENTS = [
+    'a[href]',
+    'area[href]',
+    'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
+    'select:not([disabled]):not([aria-hidden])',
+    'textarea:not([disabled]):not([aria-hidden])',
+    'button:not([disabled]):not([aria-hidden])',
+    'iframe',
+    'object',
+    'embed',
+    '[contenteditable]',
+    '[tabindex]:not([tabindex^="-"])'
+];
+
+const TAB_KEY = 9;
+const ECHAP_KEY = 27;
+
+export default class Modal extends Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            role: this.props.role || 'dialog',
+            hideClose: this.props.hideClose || false
+        }
+    }
+
+    componentDidMount() {
+        // Register last focus element
+        this.activeElement = document.activeElement;
+
+        // Register focusable nodes + Focus to the close button
+        this.focusableNodes = document.querySelector('.modal .modal-content').querySelectorAll(FOCUSABLE_ELEMENTS);
+        this.currentFocusIndex = 0;
+        this.focusableNodes[this.currentFocusIndex].focus();
+
+        // Disabled global scroll
+        document.querySelector('html').classList.add('lock-scroll');
+    }
+
+    componentDidUpdate() {
+        this.focusableNodes = document.querySelector('.modal .modal-content').querySelectorAll(FOCUSABLE_ELEMENTS);
+    }
+
+    onKeyDown = (e) => {
+        // Echap key
+        if (e.keyCode === ECHAP_KEY) { e.preventDefault(); this.closeModal(); }
+
+        // Shift-alt-key => previous focusable element
+        if (e.shiftKey && e.keyCode === TAB_KEY) {
+            e.preventDefault(); this.focusPreviousNode();
+        } else if (e.keyCode === TAB_KEY) {
+            // Tab key only
+            e.preventDefault(); this.focusNextNode();
+        }
+    }
+    focusNextNode() {
+        this.currentFocusIndex = this.currentFocusIndex + 1;
+        if (this.currentFocusIndex >= this.focusableNodes.length) this.currentFocusIndex = 0;
+        this.focusableNodes[this.currentFocusIndex].focus();
+    }
+    focusPreviousNode() {
+        this.currentFocusIndex = this.currentFocusIndex - 1;
+        if (this.currentFocusIndex < 0) this.currentFocusIndex = this.focusableNodes.length - 1;
+        this.focusableNodes[this.currentFocusIndex].focus();
+    }
+
+
+    computeCssClass() {
+        let cssClasses = 'modal-body';
+        if (this.props.cssClass) cssClasses = cssClasses.concat(' ').concat(this.props.cssClass);
+        return cssClasses;
+    }
+
+    closeModal = () => {
+        if (this.state.hideClose) return;
+
+        // Enabled scroll on the whole document
+        document.querySelector('html').classList.remove('lock-scroll');
+
+        // Focus on the last element
+        this.activeElement.focus();
+        this.props.onClose();
+    }
+
+    render() {
+        const { id, title, children } = this.props;
+        const { role, hideClose } = this.state;
+
+        return ReactDOM.createPortal(
+            <div id={id} className="modal" aria-modal="true" tabIndex="-1" role={role} aria-label={title} onKeyDown={this.onKeyDown}>
+                <div className="modal-bg" onClick={this.closeModal}>&nbsp;</div>
+                <div className="modal-content">
+                    {
+                        !hideClose ?
+                            <button className="btn close" onClick={this.closeModal}>
+                                <span className="sr-only">Fermer la fenêtre</span>
+                                <span className="icon close-icon">&nbsp;</span>
+                            </button> : null
+                    }
+                    {children}
+                </div>
+            </div>, document.body);
+    }
+}

--- a/frontend/src/components/shared/notification_modal/notification_modal.js
+++ b/frontend/src/components/shared/notification_modal/notification_modal.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 import { NOTIFICATION_STORE } from '../../../services/notification/notification.store';
 import { NotificationService } from '../../../services/notification/notification.service';
+import Modal from '../modal';
 
 require('./notification_modal.css');
 
@@ -18,6 +19,7 @@ export class NotificationModal extends Component {
     shouldComponentUpdate(nextProps, nextState) {
         if(!this.state.notification && !nextState.notification) return false;
         if(this.state.notification === nextState.notification) return false;
+        return true;
     }
 
     componentWillMount() {
@@ -47,15 +49,9 @@ export class NotificationModal extends Component {
         if (!this.state.notification) return null;
 
         return (
-            <div id="notification-modal" className="modal">
-                <div className="modal-bg" onClick={this.onClose}>&nbsp;</div>
-                <div className="modal-content">
-                    <button className="close" onClick={this.onClose}>
-                        <span className="icon close-icon">&nbsp;</span>
-                    </button>
-                    <div className="text">{this.state.notification.messages[0]}</div>
-                </div>
-            </div>
+            <Modal id="notification-modal" title={this.state.notification.messages[0]} onClose={this.onClose}>
+                <div className="text">{this.state.notification.messages[0]}</div>
+            </Modal>
         );
     }
 }

--- a/frontend/src/services/notification/notification.service.js
+++ b/frontend/src/services/notification/notification.service.js
@@ -23,7 +23,7 @@ class NotificationServiceFactory {
         return false;
     }
 
-    createInfo(messages, key= undefined) {
+    createInfo(messages, key=undefined) {
         let createNotification = this._handleKey(key);
         if (!createNotification) return;
 

--- a/frontend/src/style/global.scss
+++ b/frontend/src/style/global.scss
@@ -81,6 +81,7 @@ button.close {
     background: none;
     color: white;
     font-size: 1.5em;
+    z-index: 5;
 
     position: absolute;
     right: 10px;
@@ -100,6 +101,10 @@ ul.three-columns { columns: 3; }
         content: '';
     }
 }
+
+/* Lock the scroll position by adding this class to the `<html>` element. */
+.lock-scroll { overflow: hidden !important; }
+
 
 @-webkit-keyframes dotty {
     0%   { content: ''; }


### PR DESCRIPTION
**Accessibility rules for modal :**
  - When the Modal is not open, it is not rendered into the DOM ==> need to be handle in parent component
  - ✅ When rendered, the Modal is appended to the end of document.body. ==> Done with preact-portal
  - ✅ The Modal has relevant WAI-ARIA attributes in accordance with accessibility guidelines
     => aria-modal="true"
     => role="dialog" ou "alertdialog" (last one if immediate attention is required)
     => aria-label
  - ✅ Pressing the escape key will close the Modal.
  - ✅ Clicking outside the Modal will close it.
  - ✅ When open, scrolling is frozen on the main document beneath the Modal.
  - ✅ When open, focus is drawn immediately to the Modal's close button.
  - ✅ When the Modal closes, focus returns to the Modal's trigger button.
  - ✅ Focus is trapped within the Modal when open => ensure by tabindex="-1"
 
**Sources :**
  - https://assortment.io/posts/accessible-modal-component-react-portals-part-1
  - https://assortment.io/posts/accessible-modal-component-react-portals-part-2
 