### PR TITLE
Remove the googlemanagertag script

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -67,15 +67,6 @@
       }
     }
   </script>
-
-  <!-- Global site tag (gtag.js) - Google Ads: 963904050 -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-963904050"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-    gtag('config', 'AW-963904050');
-  </script>
 </head>
 
 <body>


### PR DESCRIPTION
This role is handled by ReactGA. And by the way, include googlemanagertag download other Google scripts that we don't want....