### PR TITLE
Remove Google Adword conversion event

### DIFF
--- a/frontend/src/components/companies/blocks/company_list_item.js
+++ b/frontend/src/components/companies/blocks/company_list_item.js
@@ -4,7 +4,6 @@ import React, { Component } from 'react';
 import { CompanyDetailsService } from '../../../services/company_details/company_details.service';
 import FavoriteButton from '../../shared/favorite_button/favorite_button';
 import { VISITED_SIRETS_STORE } from '../../../services/visited_sirets/visited_sirets.store';
-import { GoogleAdwordsService } from '../../../services/google_adword.service';
 import { FAVORITES_STORE } from '../../../services/favorites/favorites.store';
 
 export class CompanyListItem extends Component {
@@ -16,7 +15,6 @@ export class CompanyListItem extends Component {
 
     selectCompany = () => {
         CompanyDetailsService.setCompany(this.props.company);
-        GoogleAdwordsService.sendCompanyModalConversion();
     }
 
     hasBeenVisited = (siret) => {

--- a/frontend/src/components/companies/blocks/company_modal.js
+++ b/frontend/src/components/companies/blocks/company_modal.js
@@ -7,7 +7,6 @@ import { FAVORITES_STORE } from '../../../services/favorites/favorites.store';
 import FavoriteButton from '../../shared/favorite_button/favorite_button';
 import { SoftSkillsService } from '../../../services/soft_skills/soft_skills.service';
 import { CompanyDetailsCommon, CompanyCoordinates, CompanyIntroduction, PrepareApplication } from '../../shared/company_details_commun/company_details_commun';
-import { GoogleAdwordsService } from '../../../services/google_adword.service';
 import throttle from 'lodash/throttle';
 import Modal from '../../shared/modal';
 import UpdateCompanyLink from '../../shared/update-company-link';
@@ -91,7 +90,6 @@ export class CompanyModal extends Component {
     showCoordinates = () => {
         // Recording event in GA
         ReactGA.event({ category: 'Company', action: 'Open coordinates block' });
-        GoogleAdwordsService.sendCompanyCoordinatesConversion();
 
         this.setState({ showCoordinates: true }, () => this.computeCoordinatesTopValue());
     }

--- a/frontend/src/components/company_details/company_details.js
+++ b/frontend/src/components/company_details/company_details.js
@@ -20,7 +20,6 @@ import { FAVORITES_STORE } from '../../services/favorites/favorites.store';
 import { COMPANY_DETAILS_STORE } from '../../services/company_details/company_details.store';
 import { SoftSkillsService } from '../../services/soft_skills/soft_skills.service';
 import { CompanyDetailsCommon, CompanyCoordinates, CompanyIntroduction, PrepareApplication } from '../shared/company_details_commun/company_details_commun';
-import { GoogleAdwordsService } from '../../services/google_adword.service';
 import UpdateCompanyLink from '../shared/update-company-link';
 
 require('./company_details.css');
@@ -101,7 +100,6 @@ class CompanyDetails extends Component {
     showCoordinates = () => {
         // Recording event in GA
         ReactGA.event({ category: 'Company', action: 'Open coordinates block' });
-        GoogleAdwordsService.sendCompanyCoordinatesConversion();
 
         this.setState({ showCoordinates: true });
     }

--- a/frontend/src/services/google_adword.service.js
+++ b/frontend/src/services/google_adword.service.js
@@ -1,5 +1,22 @@
 export class GoogleAdwordsService {
 
+    /**
+     * IMPORTANT - To use GoogleAdword, you have to include this code in index.html
+     * See : - https://github.com/StartupsPoleEmploi/labonnealternance/pull/58
+     *       - https://github.com/StartupsPoleEmploi/labonnealternance/pull/59
+     * Note: this script will add some cookies in the site (especially the CONSENT cookie which last... 20 YEARS !)
+     *
+     *   <!-- Global site tag (gtag.js) - Google Ads: 963904050 -->
+     *   <script async src="https://www.googletagmanager.com/gtag/js?id=AW-963904050"></script>
+     *  <script>
+     *      window.dataLayer = window.dataLayer || [];
+     *      function gtag() { dataLayer.push(arguments); }
+     *      gtag('js', new Date());
+     *      gtag('config', 'AW-963904050');
+     *  </script>
+     *
+     */
+
     /* Event snippet for NEW - LBA - Tag Bouton - Afficher les coordonnées conversion page */
     static sendCompanyCoordinatesConversion() {
         window.gtag('event', 'conversion', {


### PR DESCRIPTION
Point sur le contexte :
LBa a eu une campagne Adword dans le passé et cette dernière nécessitait l'inclusion du script de GoogleTagManager. Depuis la campagne est terminée mais on inclut toujours le script. 
Le souci, c'est que ce script ajoute d'autres scripts à la page, avec son lot de cookies dont un cookie `CONSENT` qui dure 20 ans.

Du coup, je retire l'envoi des évènements liés à Adword.