### PR TITLE
Use Geo API to get commune_id from coordinates

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -24,6 +24,9 @@ export const constants = {
     // Match
     GET_SOFTSKILLS_URL: '/api/match/get_soft_skills?rome=',
 
-    // Api-adresse : get address from longitude/latitude
+    // https://adresse.data.gouv.fr/api : get address from GPS coordinates
     API_ADRESSE_URL: 'https://api-adresse.data.gouv.fr/reverse/?lon={longitude}&lat={latitude}&type=street',
+
+    // https://geo.api.gouv.fr/docs/communes : get commune_id closest to given GPS coordinates
+    GEO_API_URL: 'https://geo.api.gouv.fr/communes?lon={longitude}&lat={latitude}',
 };

--- a/frontend/src/services/companies/companies.service.js
+++ b/frontend/src/services/companies/companies.service.js
@@ -171,7 +171,7 @@ class CompaniesServiceFactory {
     }
 
     getCityCodeByCoordinates(longitude, latitude) {
-        let url = formatString(constants.API_ADRESSE_URL, { longitude, latitude });
+        let url = formatString(constants.GEO_API_URL, { longitude, latitude });
 
         return new Promise((resolve, reject) => {
             fetch(url)
@@ -179,11 +179,11 @@ class CompaniesServiceFactory {
                     if (response.status === 200) return response.json();
                     reject();
                 }).then(response => {
-                    if (!response || response.features === undefined || response.features[0] === undefined) {
+                    if (!response || response[0] === undefined || response[0].code === undefined) {
                         reject();
                         return;
                     }
-                    resolve(response.features[0].properties.citycode);
+                    resolve(response[0].code);
                 });
         });
     }


### PR DESCRIPTION
Adresse API gives unreliable results: sometimes no commune_id is returned,
and sometimes an already deleted commune_id is returned, which ends
rejected by the API Offres V2.
We use Geo API instead as it is supposed to give more reliable results.