### PR TITLE
Revert "Use Geo API to get commune_id from coordinates"

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -24,9 +24,6 @@ export const constants = {
     // Match
     GET_SOFTSKILLS_URL: '/api/match/get_soft_skills?rome=',
 
-    // https://adresse.data.gouv.fr/api : get address from GPS coordinates
+    // Api-adresse : get address from longitude/latitude
     API_ADRESSE_URL: 'https://api-adresse.data.gouv.fr/reverse/?lon={longitude}&lat={latitude}&type=street',
-
-    // https://geo.api.gouv.fr/docs/communes : get commune_id closest to given GPS coordinates
-    GEO_API_URL: 'https://geo.api.gouv.fr/communes?lon={longitude}&lat={latitude}',
 };

--- a/frontend/src/services/companies/companies.service.js
+++ b/frontend/src/services/companies/companies.service.js
@@ -171,7 +171,7 @@ class CompaniesServiceFactory {
     }
 
     getCityCodeByCoordinates(longitude, latitude) {
-        let url = formatString(constants.GEO_API_URL, { longitude, latitude });
+        let url = formatString(constants.API_ADRESSE_URL, { longitude, latitude });
 
         return new Promise((resolve, reject) => {
             fetch(url)
@@ -179,11 +179,11 @@ class CompaniesServiceFactory {
                     if (response.status === 200) return response.json();
                     reject();
                 }).then(response => {
-                    if (!response || response[0] === undefined || response[0].code === undefined) {
+                    if (!response || response.features === undefined || response.features[0] === undefined) {
                         reject();
                         return;
                     }
-                    resolve(response[0].code);
+                    resolve(response.features[0].properties.citycode);
                 });
         });
     }


### PR DESCRIPTION
This reverts commit 6e771e530810f357e2d2d6fe3ad60d6be83ff8fb and thus PR https://github.com/StartupsPoleEmploi/labonnealternance/pull/76.

I simply used the command `git revert 6e771e530810f357e2d2d6fe3ad60d6be83ff8fb`.

We revert this merged PR because it introduced a new issue. Some INSEE codes returned by the newly used Geo API (like 75056 Paris) are rejected by the API Offres V2 for unknown reasons.

API Offres V2 team is working on it but as we did not hear any news for weeks, let's just rollback this to stabilize master.