### PR TITLE
Bug fix impeding enteprise details page to be shown

### DIFF
--- a/frontend/src/components/shared/company_details_commun/company_details_commun.js
+++ b/frontend/src/components/shared/company_details_commun/company_details_commun.js
@@ -87,7 +87,7 @@ export const CompanyIntroduction = ({ company }) => {
 
             </div>
 
-            { company.offers.length >= 1 &&
+            { company.offers && company.offers.length >= 1 &&
                 <Experiment name="offres">
                     <Variant name="visibles">
                         <div className="line offers column grey padding">


### PR DESCRIPTION
This is caused because company offers may be undefined in a shared template.